### PR TITLE
issue #18 / remove a field from workstation query

### DIFF
--- a/api/workstation.go
+++ b/api/workstation.go
@@ -66,7 +66,6 @@ query fetchDomainEndpoints {
   organization {
     id
     name
-    requiresLocationServices
     uiComponentStates {
       agentBannerIsCollapsed
     }


### PR DESCRIPTION
Removing the field `requiresLocationServices` in the query `fetchDomainEndpoints` in the file `api/workstation.go` seems to solve  #18 [Unable to query table `vanta_computer`](https://github.com/turbot/steampipe-plugin-vanta/issues/18) 